### PR TITLE
Fix the height of the toolbar

### DIFF
--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -3,10 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_width="match_parent"
     android:background="?attr/colorPrimary"
-    android:fitsSystemWindows="true"
     android:minHeight="?attr/actionBarSize"
     app:popupTheme="@style/AppTheme.PopupOverlay">
 


### PR DESCRIPTION
The android:fitsSystemWindows="true" should be set in the enclosing layout. Removing from the toolbar